### PR TITLE
Formula type and disable detecting type from within strings

### DIFF
--- a/lib/axlsx.rb
+++ b/lib/axlsx.rb
@@ -165,4 +165,14 @@ module Axlsx
   def self.trust_input=(trust_me)
     @trust_input = trust_me
   end
+
+  # Instructs the serializer not to detect numeric and date types contained in strings
+  def self.disable_detect_types_from_string
+    @disable_detect_types_from_string ||= false
+  end
+
+  # @param[Boolean] disable_detect_types_from_string A boolean value indicating if string cell values should not be inspected for non-string types
+  def self.disable_detect_types_from_string=(disable_detect_types_from_string)
+    @disable_detect_types_from_string = disable_detect_types_from_string
+  end
 end

--- a/lib/axlsx/util/constants.rb
+++ b/lib/axlsx/util/constants.rb
@@ -393,5 +393,7 @@ module Axlsx
   
   FLOAT_REGEX = /\A[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?\Z/.freeze
   
+  FORMULA_REGEX = Regexp.union(/\A=.*\Z/, /\A{=.*}\Z/).freeze
+
   NUMERIC_REGEX = /\A[+-]?\d+?\Z/.freeze
 end

--- a/lib/axlsx/workbook/worksheet/cell.rb
+++ b/lib/axlsx/workbook/worksheet/cell.rb
@@ -66,7 +66,7 @@ module Axlsx
                      :vertAlign, :sz, :color, :scheme].freeze
 
     CELL_TYPES = [:date, :time, :float, :integer, :richtext,
-                  :string, :boolean, :iso_8601].freeze
+                  :string, :boolean, :iso_8601, :formula].freeze
 
     # The index of the cellXfs item to be applied to this cell.
     # @return [Integer]
@@ -126,8 +126,7 @@ module Axlsx
       type == :string &&         # String typed
         !is_text_run? &&          # No inline styles
         !@value.nil? &&           # Not nil
-        !@value.empty? &&         # Not empty
-        !@value.start_with?(?=)  # Not a formula
+        !@value.empty?            # Not empty
     end
 
     # The inline font_name property for the cell
@@ -323,11 +322,11 @@ module Axlsx
     end
 
     def is_formula?
-      type == :string && @value.to_s.start_with?(?=)
+      type == :formula
     end
 
     def is_array_formula?
-      type == :string && @value.to_s.start_with?('{=') && @value.to_s.end_with?('}')
+      type == :formula && @value.to_s.start_with?('{=') && @value.to_s.end_with?('}')
     end
 
     # returns the absolute or relative string style reference for

--- a/lib/axlsx/workbook/worksheet/cell.rb
+++ b/lib/axlsx/workbook/worksheet/cell.rb
@@ -426,14 +426,20 @@ module Axlsx
         :time
       elsif v.is_a?(TrueClass) || v.is_a?(FalseClass)
         :boolean
-      elsif v.to_s =~ Axlsx::NUMERIC_REGEX
+      elsif v.is_a?(Integer)
         :integer
-      elsif v.to_s =~ Axlsx::FLOAT_REGEX
+      elsif v.is_a?(Float)
         :float
-      elsif v.to_s =~ Axlsx::ISO_8601_REGEX
-        :iso_8601
-      elsif v.is_a? RichText
+      elsif v.is_a?(RichText)
         :richtext
+      elsif !Axlsx::disable_detect_types_from_string && v.to_s =~ Axlsx::NUMERIC_REGEX
+        :integer
+      elsif !Axlsx::disable_detect_types_from_string && v.to_s =~ Axlsx::FLOAT_REGEX
+        :float
+      elsif !Axlsx::disable_detect_types_from_string && v.to_s =~ Axlsx::ISO_8601_REGEX
+        :iso_8601
+      elsif !Axlsx::disable_detect_types_from_string && v.to_s =~ Axlsx::FORMULA_REGEX
+        :formula
       else
         :string
       end

--- a/lib/axlsx/workbook/worksheet/cell_serializer.rb
+++ b/lib/axlsx/workbook/worksheet/cell_serializer.rb
@@ -109,22 +109,30 @@ module Axlsx
         str << '</is>'
       end
 
+      # Serializes cells that are type formula
+      # @param [Cell] cell The cell that is being serialized
+      # @param [String] str The string the serialized content will be appended to.
+      # @return [String]
+      def formula(cell, str='')
+        if cell.is_array_formula?
+          array_formula_serialization cell, str
+        else
+          formula_serialization cell, str
+        end
+      end
+
       # Serializes cells that are type string
       # @param [Cell] cell The cell that is being serialized
       # @param [String] str The string the serialized content will be appended to.
       # @return [String]
       def string(cell, str='')
-        if cell.is_array_formula?
-          array_formula_serialization cell, str
-        elsif cell.is_formula?
-          formula_serialization cell, str
-        elsif !cell.ssti.nil?
-          value_serialization 's', cell.ssti, str
-        else
+        if cell.ssti.nil?
           inline_string_serialization cell, str
+        else
+          value_serialization 's', cell.ssti, str
         end
       end
-      
+
       # Serializes cells that are of the type richtext
       # @param [Cell] cell The cell that is being serialized
       # @param [String] str The string the serialized content will be appended to.

--- a/test/workbook/worksheet/tc_cell.rb
+++ b/test/workbook/worksheet/tc_cell.rb
@@ -83,20 +83,48 @@ class TestCell < Test::Unit::TestCase
     assert_equal(Axlsx.col_ref(0), "A")
   end
 
-  def test_cell_type_from_value
+  def test_cell_type_from_value_with_detection
+    cur_disable_detect_types_from_string = Axlsx::disable_detect_types_from_string
+
+    Axlsx::disable_detect_types_from_string = false
     assert_equal(@c.send(:cell_type_from_value, 1.0), :float)
+    assert_equal(@c.send(:cell_type_from_value, "2.0"), :float)
+    assert_equal(@c.send(:cell_type_from_value, 1.0/10**6), :float)
     assert_equal(@c.send(:cell_type_from_value, 1), :integer)
+    assert_equal(@c.send(:cell_type_from_value, "2"), :integer)
+    assert_equal(@c.send(:cell_type_from_value, -1), :integer)
+    assert_equal(@c.send(:cell_type_from_value, "-2"), :integer)
     assert_equal(@c.send(:cell_type_from_value, Date.today), :date)
     assert_equal(@c.send(:cell_type_from_value, Time.now), :time)
     assert_equal(@c.send(:cell_type_from_value, []), :string)
     assert_equal(@c.send(:cell_type_from_value, "d"), :string)
     assert_equal(@c.send(:cell_type_from_value, nil), :string)
-    assert_equal(@c.send(:cell_type_from_value, -1), :integer)
+    assert_equal(@c.send(:cell_type_from_value, "=SUM(A1:A2)"), :formula)
+    assert_equal(@c.send(:cell_type_from_value, "{=SUM(A1:A2*B1:B2)}"), :formula)
     assert_equal(@c.send(:cell_type_from_value, true), :boolean)
     assert_equal(@c.send(:cell_type_from_value, false), :boolean)
-    assert_equal(@c.send(:cell_type_from_value, 1.0/10**6), :float)
     assert_equal(@c.send(:cell_type_from_value, Axlsx::RichText.new), :richtext)
-    assert_equal(:iso_8601, @c.send(:cell_type_from_value, '2008-08-30T01:45:36.123+09:00'))
+    assert_equal(@c.send(:cell_type_from_value, "2008-08-30T01:45:36.123+09:00"), :iso_8601)
+  ensure
+    Axlsx::disable_detect_types_from_string = cur_disable_detect_types_from_string
+  end
+
+  def test_cell_type_from_value_without_detection
+    cur_disable_detect_types_from_string = Axlsx::disable_detect_types_from_string
+
+    Axlsx::disable_detect_types_from_string = true
+    assert_equal(@c.send(:cell_type_from_value, 1.0), :float)
+    assert_equal(@c.send(:cell_type_from_value, "2.0"), :string)
+    assert_equal(@c.send(:cell_type_from_value, 1.0/10**6), :float)
+    assert_equal(@c.send(:cell_type_from_value, 1), :integer)
+    assert_equal(@c.send(:cell_type_from_value, "2"), :string)
+    assert_equal(@c.send(:cell_type_from_value, -1), :integer)
+    assert_equal(@c.send(:cell_type_from_value, "-2"), :string)
+    assert_equal(@c.send(:cell_type_from_value, "=SUM(A1:A2)"), :string)
+    assert_equal(@c.send(:cell_type_from_value, "{=SUM(A1:A2*B1:B2)}"), :string)
+    assert_equal(@c.send(:cell_type_from_value, "2008-08-30T01:45:36.123+09:00"), :string)
+  ensure
+    Axlsx::disable_detect_types_from_string = cur_disable_detect_types_from_string
   end
 
   def test_cast_value


### PR DESCRIPTION
- new formula type allows creating string cells with text that begins with `=`
- allow disabling the detection of number and formula types contained in string cells

We would like to be able to put text in cells without worrying about its contents, just have it end up as text. For our cases we usually have numbers already in their expected ruby types and don't rely on the Excel-y behavior of type detection.